### PR TITLE
fix(config): correct variable name typo to ensure proper configuration loading

### DIFF
--- a/shared/config.lua
+++ b/shared/config.lua
@@ -17,4 +17,4 @@
 config = {}
 
 config.DebugCommands = false -- This is for testing purposes only. Set to true to enable debug commands.
-coifig.usingGlitchNotifications = true -- Set to true to enable glitch notifications.
+config.usingGlitchNotifications = true -- Set to true to enable glitch notifications.


### PR DESCRIPTION
fix(config): correct variable name typo to ensure proper configuration loading