### PR TITLE
fix(bruteForce): only unfreeze player if frozen by minigame to prevent unintended unfreeze

### DIFF
--- a/client/bruteForce/bruteForce.lua
+++ b/client/bruteForce/bruteForce.lua
@@ -23,6 +23,8 @@ local gamePassword
 local inMinigame = false
 local minigameResult = nil
 
+local PlayerFreezed = false
+
 local function cleanupControls()
     FreezeEntityPosition(PlayerPedId(), false)
     EnableControlAction(0, 24, true) -- LEFT CLICK
@@ -129,6 +131,7 @@ Citizen.CreateThread(function()
         Citizen.Wait(0)
         if inMinigame and HasScaleformMovieLoaded(scaleform) then
             FreezeEntityPosition(PlayerPedId(), true)
+            PlayerFreezed = true
             DisableControlAction(0, 24, true)
             DisableControlAction(0, 25, true)
             
@@ -291,7 +294,10 @@ Citizen.CreateThread(function()
                 end
             end
         else
-            FreezeEntityPosition(PlayerPedId(), false)
+            if PlayerFreezed then 
+                FreezeEntityPosition(PlayerPedId(), false)
+                PlayerFreezed = false
+            end
             Citizen.Wait(500)
         end
     end


### PR DESCRIPTION
This update ensures that the player is only unfrozen if the minigame was responsible for freezing them. Previously, the script would unfreeze the player regardless of how they became frozen, which could interfere with other systems or scripts.

### Changes:
- Added `PlayerFreezed` flag to track if the minigame initiated the freeze
- Updated logic to unfreeze only if `PlayerFreezed` is true
- Prevents potential conflicts with other gameplay mechanics or scripts that rely on freezing the player

This improves compatibility and prevents bugs caused by premature or unintended unfreezing.
